### PR TITLE
메뉴 rest docs 추가 및 버그 수정

### DIFF
--- a/src/docs/asciidoc/Menu.adoc
+++ b/src/docs/asciidoc/Menu.adoc
@@ -1,0 +1,52 @@
+[[Menu-API]]
+== Menu API
+
+[[Menu-Create]]
+=== Menu-Create
+operation::menu-create[snippets='http-request,request-fields,http-response,response-fields']
+
+.curl
+[%collapsible]
+====
+include::{snippets}/menu-create/curl-request.adoc[]
+====
+
+[[Menu-Update]]
+=== Recipe-Update
+operation::menu-update[snippets='http-request,path-parameters,request-fields,http-response']
+
+.curl
+[%collapsible]
+====
+include::{snippets}/menu-update/curl-request.adoc[]
+====
+
+[[Menu-Delete]]
+=== Menu-Delete
+operation::menu-delete[snippets='http-request,path-parameters,http-response']
+
+.curl
+[%collapsible]
+====
+include::{snippets}/menu-delete/curl-request.adoc[]
+====
+
+[[Menu-Get]]
+=== Menu-Get
+operation::menu-get[snippets='http-request,path-parameters,http-response,response-fields']
+
+.curl
+[%collapsible]
+====
+include::{snippets}/menu-get/curl-request.adoc[]
+====
+
+[[Menu-GetAll]]
+=== Menu-GetAll
+operation::menu-getAll[snippets='http-request,http-response,response-fields']
+
+.curl
+[%collapsible]
+====
+include::{snippets}/menu-getAll/curl-request.adoc[]
+====

--- a/src/main/java/com/bh/rms/infra/InMemoryMenuRepository.java
+++ b/src/main/java/com/bh/rms/infra/InMemoryMenuRepository.java
@@ -22,7 +22,7 @@ public class InMemoryMenuRepository implements MenuRepository {
 
     @Override
     public String create(Menu menu) {
-        menu.setId(String.format("material%d", atomicInteger.incrementAndGet()));
+        menu.setId(String.format("menu%d", atomicInteger.incrementAndGet()));
         menuMap.put(menu.getId(), menu);
         return menu.getId();
     }

--- a/src/main/java/com/bh/rms/web/menu/MenuController.java
+++ b/src/main/java/com/bh/rms/web/menu/MenuController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@RequestMapping("/api")
 @RestController
 public class MenuController {
     private final MenuService menuService;
@@ -14,7 +15,7 @@ public class MenuController {
         this.menuService = menuService;
     }
 
-    @PostMapping("/menu")
+    @PostMapping("/menus")
     public MenuCreateResponse create(@RequestBody MenuCreateRequest request) {
         Menu menu = request.makeForCreate();
         menuService.create(menu);

--- a/src/test/java/com/bh/rms/integration/document/fixture/MenuFixtureGenerator.java
+++ b/src/test/java/com/bh/rms/integration/document/fixture/MenuFixtureGenerator.java
@@ -1,0 +1,65 @@
+package com.bh.rms.integration.document.fixture;
+
+import com.bh.rms.web.menu.MenuController;
+import com.bh.rms.web.menu.MenuCreateRequest;
+import com.bh.rms.web.menu.MenuUpdateRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Component
+public class MenuFixtureGenerator {
+
+    private final MenuController menuController;
+    private final RecipeFixtureGenerator recipeFixtureGenerator;
+    private Set<String> menuIdSet;
+
+    public MenuFixtureGenerator(MenuController menuController, RecipeFixtureGenerator recipeFixtureGenerator) {
+        this.menuController = menuController;
+        this.recipeFixtureGenerator = recipeFixtureGenerator;
+        this.menuIdSet = new HashSet<>();
+    }
+    
+    public String createMenu() {
+        String menuId = menuController.create(getMenuCreateRequest()).getId();
+        menuIdSet.add(menuId);
+        return menuId;
+    }
+
+    public MenuCreateRequest getMenuCreateRequest() {
+        MenuCreateRequest request = new MenuCreateRequest();
+        String recipeId = recipeFixtureGenerator.createRecipe();
+        request.setRecipeId(recipeId);
+        request.setName("menu");
+        request.setPrice(1000);
+        return request;
+    }
+
+    public MenuUpdateRequest getMenuUpdateRequest() {
+        MenuUpdateRequest request = new MenuUpdateRequest();
+        String recipeId = recipeFixtureGenerator.createRecipe();
+        request.setRecipeId(recipeId);
+        request.setName("menu");
+        request.setPrice(1000);
+        return request;
+    }
+
+    public void cleanUp() {
+        for(String menuId : menuIdSet) {
+            deleteMenu(menuId);
+        }
+        menuIdSet = new HashSet<>();
+    }
+
+
+    public void deleteMenu(String menuId) {
+        try {
+            menuController.delete(menuId);
+        } catch (Exception e) {
+            log.warn("Delete menu failed. menuId: " + menuId + " ,message: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/bh/rms/integration/document/test/MenuDocumentTest.java
+++ b/src/test/java/com/bh/rms/integration/document/test/MenuDocumentTest.java
@@ -1,0 +1,183 @@
+package com.bh.rms.integration.document.test;
+
+import com.bh.rms.integration.document.fixture.MenuFixtureGenerator;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.bh.rms.integration.document.config.DocumentProcessor.getRequestPreprocessor;
+import static com.bh.rms.integration.document.config.DocumentProcessor.getResponsePreprocessor;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MenuDocumentTest extends AbstractDocumentTest {
+
+    @Autowired
+    MenuFixtureGenerator menuFixtureGenerator;
+
+    @AfterEach
+    public void afterEach() {
+        menuFixtureGenerator.cleanUp();
+    }
+
+    @Test
+    void createMenu() throws Exception {
+        ResultActions resultActions = getMockMvc().perform(
+                post("/api/menus")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(makeJsonString(menuFixtureGenerator.getMenuCreateRequest()))
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andDo(log())
+                .andDo(
+                        document("menu-create",
+                                getRequestPreprocessor(), getResponsePreprocessor(),
+                                requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING)
+                                                .description("name of menu").optional().attributes(key("constraint").value("can not be empty.")),
+                                        fieldWithPath("price").type(JsonFieldType.NUMBER)
+                                                .description("price of menu").optional().attributes(key("constraint").value("price >= 0.")),
+                                        fieldWithPath("recipeId").type(JsonFieldType.STRING)
+                                                .description("recipeId of menu").optional().attributes(key("constraint").value("can not be empty."))
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.STRING)
+                                                .description("identifier of menu")
+                                )
+                        )
+                )
+                .andDo(result -> {
+                    String id = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
+                    menuFixtureGenerator.deleteMenu(id);
+                });
+    }
+
+    @Test
+    void updateMenu() throws Exception {
+        String id = menuFixtureGenerator.createMenu();
+
+        ResultActions resultActions = getMockMvc().perform(
+                put("/api/menus/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeJsonString(menuFixtureGenerator.getMenuUpdateRequest()))
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(log())
+                .andDo(
+                        document("menu-update",
+                                getRequestPreprocessor(), getResponsePreprocessor(),
+                                pathParameters(parameterWithName("id").description("id of menu")),
+                                requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING)
+                                                .description("name of menu").optional().attributes(key("constraint").value("can not be empty.")),
+                                        fieldWithPath("price").type(JsonFieldType.NUMBER)
+                                                .description("price of menu").optional().attributes(key("constraint").value("price >= 0.")),
+                                        fieldWithPath("recipeId").type(JsonFieldType.STRING)
+                                                .description("recipeId of menu").optional().attributes(key("constraint").value("can not be empty."))
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void deleteMenu() throws Exception {
+        String id = menuFixtureGenerator.createMenu();
+
+        ResultActions resultActions = getMockMvc().perform(
+                delete("/api/menus/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(log())
+                .andDo(
+                        document("menu-delete",
+                                getRequestPreprocessor(), getResponsePreprocessor(),
+                                pathParameters(parameterWithName("id").description("id of menu"))
+                        )
+                );
+    }
+
+    @Test
+    void getMenu() throws Exception {
+        String id = menuFixtureGenerator.createMenu();
+
+        ResultActions resultActions = getMockMvc().perform(
+                get("/api/menus/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name").exists())
+                .andExpect(jsonPath("$.price").exists())
+                .andExpect(jsonPath("$.recipeId").exists())
+                .andDo(log())
+                .andDo(
+                        document("menu-get",
+                                getRequestPreprocessor(), getResponsePreprocessor(),
+                                pathParameters(parameterWithName("id").description("id of menu")),
+                                responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.STRING).description("identifier of menu"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("name of menu"),
+                                        fieldWithPath("price").type(JsonFieldType.NUMBER).description("price of menu"),
+                                        fieldWithPath("recipeId").type(JsonFieldType.STRING).description("recipeId of menu")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void getMenus() throws Exception {
+        menuFixtureGenerator.createMenu();
+        menuFixtureGenerator.createMenu();
+
+        ResultActions resultActions = getMockMvc().perform(
+                get("/api/menus")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.[0].id").exists())
+                .andExpect(jsonPath("$.[1].id").exists())
+                .andExpect(jsonPath("$.[2].id").doesNotExist())
+                .andDo(log())
+                .andDo(
+                        document("menu-getAll",
+                                getRequestPreprocessor(), getResponsePreprocessor(),
+                                responseFields(
+                                        fieldWithPath("[]").type(JsonFieldType.ARRAY).description("all of menu"),
+                                        fieldWithPath("[].id").type(JsonFieldType.STRING).description("identifier of menu"),
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("name of menu"),
+                                        fieldWithPath("[].price").type(JsonFieldType.NUMBER).description("price of menu"),
+                                        fieldWithPath("[].recipeId").type(JsonFieldType.STRING).description("recipeId of menu")
+                                )
+                        )
+                );
+    }
+}


### PR DESCRIPTION
주문 rest docs 만들 때 MenuFixtureGenerator가 없어서 만드는 김에 테스트도 추가했습니다!
겸사겸사 버그 조금 수정도 했습니다

- 메뉴 rest docs 추가
- 메뉴 api url 수정 
  - `"/api"` prefix 추가 `"/menus"` -> `"/api/menus"`
  - 생성 api 오타 수정 `"/menu"` -> `"/menus"` 
- InMemoryMenuRepository에서 menuId가 `material~`로 만들어지게 되어있는 부분 수정